### PR TITLE
Fix for albums containing a path separator character

### DIFF
--- a/lib/photobox.js
+++ b/lib/photobox.js
@@ -163,7 +163,7 @@ module.exports = function (logger){
     downloadPagePhotos : function (options, callback) {
       var self = this;
       var photos = this.getPhotos(options.body);
-      var outputDir = path.join(options.outputDir, options.album.name);
+      var outputDir = path.join(options.outputDir, options.album.name.replace(/\\{1,}|\/{1,}/, '_'));
 
       if (!fs.existsSync(options.outputDir)) {
         fs.mkdirSync(options.outputDir);


### PR DESCRIPTION
When an album contains a path separator, the code that creates a directory doesn't take that into account and fails. This fix replaces any / or \ characters with underscores.