### PR TITLE
feat: Implemented addition of User-Agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Alternatively, you can use cURL to get it (username and password have to url enc
 export EMAIL="yourmemail%40gmail.com" # url encoded email address
 export PASS="password"
 
-curl 'https://www.photobox.ie/' -H 'User-Agent: ' \
+curl 'https://www.photobox.ie/' -H 'User-Agent: photobox-downloader' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Accept: text/html,*/*;q=0.8' \
  -H 'Cache-Control: max-age=0' --cookie-jar - \

--- a/lib/photobox.js
+++ b/lib/photobox.js
@@ -18,6 +18,8 @@ var request;
 var config;
 var winston = require('winston');
 var MAX_ATTEPMTS = 3;
+var { version } = require('../package.json');
+var requestHeaders = { 'User-Agent': 'photobox-downloader/' + version }
 
 module.exports = function (logger){
   logger = logger || console;
@@ -32,8 +34,8 @@ module.exports = function (logger){
 
       request = request.defaults({jar : j});
       var albumUrl = 'http://' + config.baseDomain + '/my/albums';
-      logger.debug('Requesting page to verify login status:', albumUrl)
-      request(albumUrl, function (err, response, body) {
+      logger.debug('Requesting page to verify login status:', albumUrl, 'with headers:', requestHeaders)
+      request({ url: albumUrl, headers: requestHeaders }, function (err, response, body) {
         if (!err && response.statusCode === 200) {
           logger.debug('Login request did not generate HTTP error, checking html now...');
           var $ = cheerio.load(body);
@@ -109,7 +111,7 @@ module.exports = function (logger){
 
       var photoUrl = 'http://' + config.baseDomain + '/my/photo/full?photo_id=' + options.id;
       var self = this;
-      request(photoUrl,
+      request({ url: photoUrl, headers: requestHeaders },
         function (err, response, body) {
           logger.debug('Downloading Photo');
           if (!err && response.statusCode === 200) {
@@ -138,7 +140,7 @@ module.exports = function (logger){
               logger.debug('  Saving to: ', filePath);
               try {
                 if (options.attempts < MAX_ATTEPMTS) {
-                  request($('img').attr('src'), callback).pipe(fs.createWriteStream(filePath));
+                  request({ url: $('img').attr('src'), headers: requestHeaders }, callback).pipe(fs.createWriteStream(filePath));
                 } else {
                   callback("Number of photo download attmpts exceeded!");
                 }
@@ -213,7 +215,7 @@ module.exports = function (logger){
     getAlbumPages : function (album, callback) {
 
       var pageRequests = [];
-      request('http://' + config.baseDomain + album.link, function (err, response, body) {
+      request({ url: 'http://' + config.baseDomain + album.link, headers: requestHeaders }, function (err, response, body) {
         if (!err && response.statusCode === 200) {
 
           pageRequests.push(body);
@@ -236,7 +238,7 @@ module.exports = function (logger){
             async.eachSeries(
               pageLinks,
               function (link, callbackFn) {
-                request('http://' + config.baseDomain + '/my/album' + link, function (err, response, body) {
+                request({ url: 'http://' + config.baseDomain + '/my/album' + link, headers: requestHeaders }, function (err, response, body) {
                   if (!err && response.statusCode === 200) {
                     pageRequests.push(body);
                     setTimeout(function () {


### PR DESCRIPTION
Photobox has recently introduced WAF to their core endpoints. This WAF will treat a blank User-Agent as invalid and drop the response. I've updated the request calls to add a User-Agent field based on the name photobox-downloader and a version I'm deriving from package.json.
I've also updated the cURL command used for grabbing the authentication cookie.